### PR TITLE
4530 add toggle persist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# feature-toggle-manager
+# Feature Toggle Manager
+
+The feature toggle manager knows how to read statuses of current feature toggles from `localStorage.getItem('featureToggles')` as well as from `window.featureToggleStatuses`.
+
+## Static Methods
+### hasFeature()
+Use this method whenever a feature toggle switch needs to happen in the code.
+```
+/**
+  * Check if a particular feature toggle is turned on.
+  * Returns a boolean.
+  */
+FeatureToggleManager.hasFeature('some_amazing_feature');
+```
+
+## Instantiated Methods
+### new FeatureToggleManager()
+For more complicated setups which allow feature toggles to be turned on via the query string, instantiate a feature toggle manager object, which will automatically collect available feature toggles from browser localStorage and window.
+
+### updateTogglesBasedOnQueryStringCommands()
+To update the feature toggle in localStorage based on query string commands, call this method.
+
+The query string commands to toggle on and off features are these:
+`featureon=the_feature_you_want_turned_on`
+`featureoff=the_feature_you_want_turned_off`
+```
+/**
+  * Checks the browser's query string and turns on or off 
+  * any feature toggles based on those settings.
+  * Returns void.
+  */
+const manager = new FeatureToggleManager();
+manager.updateTogglesBasedOnQueryStringCommands();
+```
+

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -1,3 +1,3 @@
 interface Window {
-  featureToggles: string;
+  featureToggleStatuses: string;
 }

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -1,4 +1,4 @@
 interface Window {
-  featureToggleStatuses: string;
+  featureToggleList: string;
   showFeatures: () => string;
 }

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -1,3 +1,4 @@
 interface Window {
   featureToggleStatuses: string;
+  showFeatures: () => string;
 }

--- a/src/js-feature-toggle-manager.test.ts
+++ b/src/js-feature-toggle-manager.test.ts
@@ -1,39 +1,104 @@
-import { FeatureToggleManager } from './js-feature-toggle-manager';
+import { SavedToggleListStatus, ToggleStatus, FeatureToggleManager } from './js-feature-toggle-manager';
 
-QUnit.module('FeatureToggleManager tests');
+QUnit.module('FeatureToggleManager tests', {
+  beforeEach: () => {
+    window.localStorage.clear();
+    window.featureToggleStatuses = '';
+  }
+});
 
-QUnit.test('can check feature enabled', assert => {
-  window.featureToggles = JSON.stringify(['feature_toggle_a']);
-  assert.ok(FeatureToggleManager.hasFeature('a'), 'feature toggle a should exist');
-  assert.notOk(FeatureToggleManager.hasFeature('b'), 'feature toggle should not exist');
+QUnit.test('can check for features enabled', assert => {
+  const toggleSetter = new WindowToggleSetter();
+  toggleSetter.setToggle('feature_that_does_exist', true);
+  toggleSetter.setToggle('feature_that_is_toggled_off', false);
+  toggleSetter.writeToWindowToggles();
+  assert.ok(FeatureToggleManager.hasFeature('feature_that_does_exist'));
+  assert.notOk(FeatureToggleManager.hasFeature('feature_that_is_toggled_off'));
+  assert.notOk(FeatureToggleManager.hasFeature('feature_that_does_not_exist'));
 });
 
 QUnit.test('should work with undefined', assert => {
-  window.featureToggles = undefined;
+  window.featureToggleStatuses = undefined;
   assert.notOk(FeatureToggleManager.hasFeature(undefined), 'Undefined feature toggle should not exist');
 });
 
 QUnit.test('should work with null', assert => {
-  window.featureToggles = null;
+  window.featureToggleStatuses = null;
   assert.notOk(FeatureToggleManager.hasFeature(null), 'NULL feature toggle should not exist');
 });
 
-QUnit.test('should allow empty array', assert => {
-  window.featureToggles = '[]';
-  assert.notOk(FeatureToggleManager.hasFeature('a'), 'a feature toggle should not exist');
-});
-
-QUnit.test('should stringify JSON empty object should work', assert => {
-  window.featureToggles = JSON.stringify({});
-  assert.notOk(FeatureToggleManager.hasFeature('a'), 'a feature toggle should not exist');
-});
-
 QUnit.test('should stringify JSON empty array should work', assert => {
-  window.featureToggles = JSON.stringify([]);
+  const toggleSetter = new WindowToggleSetter();
+  toggleSetter.writeToWindowToggles();
   assert.notOk(FeatureToggleManager.hasFeature('a'), 'a feature toggle should not exist');
 });
 
 QUnit.test('should find feature toggle', assert => {
-  window.featureToggles = `["catalog_notification"]`;
+  const toggleSetter = new WindowToggleSetter();
+  toggleSetter.setToggle('catalog_notification', true);
+  toggleSetter.writeToWindowToggles();
   assert.ok(FeatureToggleManager.hasFeature('catalog_notification'), 'catalog_notification exists');
 });
+
+QUnit.test('Can get feature toggles from local storage.', assert => {
+  const toggleSetter = new LocalStorageSetter();
+  toggleSetter.setToggle('feature_toggle_A', true);
+  toggleSetter.setLocalStorage();
+  
+  assert.ok(FeatureToggleManager.hasFeature('feature_toggle_A'));
+});
+
+QUnit.test('Local storage setting should take precedence over window feature toggles setting.', assert => {
+  const windowSetter = new WindowToggleSetter();
+  windowSetter.setToggle('feature_toggle_xyz', false);
+  windowSetter.writeToWindowToggles();
+
+  const localStorageSetter = new LocalStorageSetter();
+  localStorageSetter.setToggle('feature_toggle_xyz', true);
+  localStorageSetter.setLocalStorage();
+
+  assert.ok(FeatureToggleManager.hasFeature('feature_toggle_xyz'));
+
+  windowSetter.setToggle('feature_toggle_xyz', true);
+  windowSetter.writeToWindowToggles();
+
+  localStorageSetter.setToggle('feature_toggle_xyz', false);
+  localStorageSetter.setLocalStorage();
+
+  assert.notOk(FeatureToggleManager.hasFeature('feature_toggle_xyz'));
+});
+
+abstract class ToggleSetter {
+  protected toggles: ToggleStatus[] = [];
+
+  public setToggle(toggleName: string, toggleStatus: boolean): void {
+    this.toggles.push({
+      Name: toggleName,
+      Status: toggleStatus
+    });
+  }
+}
+
+class WindowToggleSetter extends ToggleSetter {
+  public writeToWindowToggles(): void {
+    window.featureToggleStatuses = JSON.stringify(this.toggles);
+  }
+}
+
+class LocalStorageSetter extends ToggleSetter {
+  private toggleStatus: SavedToggleListStatus;
+
+  constructor() {
+    super ();
+    this.toggleStatus = {
+      LastModifiedISO: new Date().toISOString(),
+      Toggles: []
+    };
+  }
+
+  public setLocalStorage(): void {
+    this.toggleStatus.Toggles = this.toggles;
+    window.localStorage.setItem('featureToggles', JSON.stringify(this.toggleStatus));
+    this.toggles = [];
+  }
+}

--- a/src/js-feature-toggle-manager.test.ts
+++ b/src/js-feature-toggle-manager.test.ts
@@ -3,7 +3,7 @@ import { SavedToggleListStatus, ToggleStatus, FeatureToggleManager } from './js-
 QUnit.module('FeatureToggleManager tests', {
   beforeEach: () => {
     window.localStorage.clear();
-    window.featureToggleStatuses = '';
+    window.featureToggleList = '';
   },
   afterEach: () => {
     history.pushState('', 'Reset querystring', `${window.location.pathname}`);
@@ -21,12 +21,12 @@ QUnit.test('can check for features enabled', assert => {
 });
 
 QUnit.test('should work with undefined', assert => {
-  window.featureToggleStatuses = undefined;
+  window.featureToggleList = undefined;
   assert.notOk(FeatureToggleManager.hasFeature(undefined), 'Undefined feature toggle should not exist');
 });
 
 QUnit.test('should work with null', assert => {
-  window.featureToggleStatuses = null;
+  window.featureToggleList = null;
   assert.notOk(FeatureToggleManager.hasFeature(null), 'NULL feature toggle should not exist');
 });
 
@@ -119,14 +119,14 @@ abstract class ToggleSetter {
   public setToggle(toggleName: string, toggleStatus: boolean): void {
     this.toggles.push({
       Name: toggleName,
-      Status: toggleStatus
+      IsActive: toggleStatus
     });
   }
 }
 
 class WindowToggleSetter extends ToggleSetter {
   public writeToWindowToggles(): void {
-    window.featureToggleStatuses = JSON.stringify(this.toggles);
+    window.featureToggleList = JSON.stringify(this.toggles);
   }
 }
 

--- a/src/js-feature-toggle-manager.ts
+++ b/src/js-feature-toggle-manager.ts
@@ -7,7 +7,7 @@ export interface SavedToggleListStatus {
 
 export interface ToggleStatus {
   Name: string;
-  Status: boolean;
+  IsActive: boolean;
 }
 
 export class FeatureToggleManager {  
@@ -22,7 +22,7 @@ export class FeatureToggleManager {
     const features = this.getCombinedFeatureList();
     
     const featureMatch = features.find(toggle => toggle.Name === targetFeature);
-    return undefined !== featureMatch && featureMatch.Status;
+    return undefined !== featureMatch && featureMatch.IsActive;
   }
 
   private static getFeatureListFromLocalStorage(): ToggleStatus[] {
@@ -36,20 +36,20 @@ export class FeatureToggleManager {
   }
   
   private static getFeatureListFromWindow(): ToggleStatus[] {
-    const windowFeatureToggles = window.featureToggleStatuses;
+    const toggleList = window.featureToggleList;
     let list: any;
 
-    if (!Array.isArray(windowFeatureToggles)) {
+    if (!Array.isArray(toggleList)) {
       try {
-        list = JSON.parse(windowFeatureToggles);
-        if (!Array.isArray(list)) throw new Error('List not an array.');
+        list = JSON.parse(toggleList);
+        if (!Array.isArray(list)) throw new Error('Toggle list must be an array.');
       }
       catch (e) {
         list = [];
       }
     }
     else
-      list = windowFeatureToggles;
+      list = toggleList;
 
     return list;
   }
@@ -59,10 +59,10 @@ export class FeatureToggleManager {
           winList = this.getFeatureListFromWindow();
 
     return lsList.concat(
-                  winList.filter(winToggle => {
-                      return lsList.every(lsToggle => lsToggle.Name !== winToggle.Name);
-                    })
-                  );
+                    winList.filter(winToggle => {
+                        return lsList.every(lsToggle => lsToggle.Name !== winToggle.Name);
+                      })
+                    );
   }
 
   constructor() {
@@ -79,11 +79,11 @@ export class FeatureToggleManager {
           featureToToggleOff = QueryStringReader.findQueryString('featureoff'),
           updatedToggles = this.currentToggles.map(toggle => {
             if (null !== featureToToggleOff && featureToToggleOff.value.toLowerCase() === toggle.Name.toLowerCase()) {
-              toggle.Status = false;
+              toggle.IsActive = false;
               return toggle;
             }
             else if (null !== featureToToggleOn && featureToToggleOn.value.toLowerCase() === toggle.Name.toLowerCase()) {
-              toggle.Status = true;
+              toggle.IsActive = true;
               return toggle;
             }
 
@@ -104,7 +104,7 @@ export class FeatureToggleManager {
 
   private showFeatureToggles(): string {
     return this.currentToggles.reduce((returnString, toggle) => {
-      const activeIcon = toggle.Status ? '✓' : '';
+      const activeIcon = toggle.IsActive ? '✓' : '';
       returnString += `${toggle.Name} (${activeIcon})\n`;
       return returnString;
     }, '\n');

--- a/src/js-feature-toggle-manager.ts
+++ b/src/js-feature-toggle-manager.ts
@@ -10,19 +10,18 @@ export interface ToggleStatus {
   Status: boolean;
 }
 
-export class FeatureToggleManager {
+export class FeatureToggleManager {  
+  private currentToggles: ToggleStatus[];
+  
   /**
    * Check to see if a feature is currently active.
    * @param feature The feature to check for. Do not include the feature_toggle_ prefix.
    * @example For a feature_toggle_team_ordering feature, use hasFeature('product_page_team_ordering')
    */
-  public static hasFeature(feature: string): boolean {
-    const features = this.combineFeatureLists(
-      this.getFeatureListFromLocalStorage(),
-      this.getFeatureListFromWindow()
-    );
+  public static hasFeature(targetFeature: string): boolean {
+    const features = this.getCombinedFeatureList();
     
-    const featureMatch = features.find(toggle => toggle.Name === feature);
+    const featureMatch = features.find(toggle => toggle.Name === targetFeature);
     return undefined !== featureMatch && featureMatch.Status;
   }
 
@@ -55,11 +54,59 @@ export class FeatureToggleManager {
     return list;
   }
 
-  private static combineFeatureLists(lsList: ToggleStatus[], winList: ToggleStatus[]): ToggleStatus[] {
+  private static getCombinedFeatureList(): ToggleStatus[] {
+    const lsList = this.getFeatureListFromLocalStorage(),
+          winList = this.getFeatureListFromWindow();
+
     return lsList.concat(
                   winList.filter(winToggle => {
                       return lsList.every(lsToggle => lsToggle.Name !== winToggle.Name);
                     })
                   );
+  }
+
+  constructor() {
+    this.currentToggles = FeatureToggleManager.getCombinedFeatureList();
+    window.showFeatures = this.showFeatureToggles.bind(this);
+  }
+
+  /**
+   * Update feature toggles in local storage based on query string options.
+   * @example for a querystring that contains the string 'featureoff=some_feature', the feature toggle some_feature will be deactivated.
+   */
+  public updateTogglesBasedOnQueryStringCommands(): void {
+    const featureToToggleOn = QueryStringReader.findQueryString('featureon'),
+          featureToToggleOff = QueryStringReader.findQueryString('featureoff'),
+          updatedToggles = this.currentToggles.map(toggle => {
+            if (null !== featureToToggleOff && featureToToggleOff.value.toLowerCase() === toggle.Name.toLowerCase()) {
+              toggle.Status = false;
+              return toggle;
+            }
+            else if (null !== featureToToggleOn && featureToToggleOn.value.toLowerCase() === toggle.Name.toLowerCase()) {
+              toggle.Status = true;
+              return toggle;
+            }
+
+            return toggle;
+          });
+    
+    this.setLocalStorage(updatedToggles);
+  }
+
+  private setLocalStorage(toggles: ToggleStatus[]): void {
+    const toggleStatus: SavedToggleListStatus = {
+      LastModifiedISO: new Date().toISOString(),
+      Toggles: toggles
+    };
+
+    window.localStorage.setItem('featureToggles', JSON.stringify(toggleStatus));
+  }
+
+  private showFeatureToggles(): string {
+    return this.currentToggles.reduce((returnString, toggle) => {
+      const activeIcon = toggle.Status ? '✓' : '';
+      returnString += `${toggle.Name} (${activeIcon})\n`;
+      return returnString;
+    }, '\n');
   }
 }


### PR DESCRIPTION
This is a fairly major overhaul of the feature toggle manager. The whole concept changed from one of accessing an in-memory array of toggle names to persisting a list of toggles along with their statuses. This is only the FE bit of course. We'll end up having a very similar version in the business objects as well that code behinds can access.

@someyoungideas you'll also have to remind me how to add a version tag to this Pull Request once it's finished.

One last thing: I'd love to spend a little time thinking about how we want to do our ReadMe files. It would be fun to make this repo our standard that we could reference as we go forward with others.