### PR TITLE
Make toggles public

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ FeatureToggleManager.hasFeature('some_amazing_feature');
 ### Console Toggle View
 In order to activate a method which will allow users to issue a console command to see which feature toggles are activated, you will need to get an instance of the feature toggle manager.
 
-You can do this by calling this method:
+Get an instance of the feature toggle manager:
 ```
 const myFeatureToggleManager = FeatureToggleManager.instance;
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ FeatureToggleManager.hasFeature('some_amazing_feature');
 ```
 
 ## Instantiated Methods
-
+### Console Toggle View
 In order to activate a method which will allow users to issue a console command to see which feature toggles are activated, you will need to get an instance of the feature toggle manager.
 
 You can do this by calling this method:
@@ -31,11 +31,14 @@ feature_toggle_y (✓)
 feature_toggle_z ()
 ```
 
+### GUI Toggle View
 To provide a graphical user interface to users, you will need an instance of `FeatureToggleDisplayPanel`:
 ```
-const myDisplayPanel = FeatureToggleDisplayPanel(featureToggles), // Pass in an array of toggles.
-      myFeatureToggleManager = FeatureToggleManager.instance;
-myFeatureToggleManager.createDisplayPanel(myDisplayPanel);
+const myFeatureToggleManager = FeatureToggleManager.instance,
+      availableToggles = myFeatureToggleManager.toggles,
+      displayPanel = myFeatureToggleManager.createDisplayPanel(new FeatureToggleDisplayPanel(availableToggles));
+
+// displayPanel will be a div element containing the user interface.
 ```
 
-This is a barebones interface. The styling needs to be implemented by the consumer.
+This is a barebones user interface. The consumer will need to make the styling decisions.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use this method whenever a feature toggle switch needs to happen in the code.
   * Check if a particular feature toggle is turned on.
   * Returns a boolean.
   */
-FeatureToggleManager.hasFeature('some_amazing_feature');
+FeatureToggleManager.HasFeature('some_amazing_feature');
 ```
 
 ## Instantiated Methods
@@ -19,7 +19,7 @@ In order to activate a method which will allow users to issue a console command 
 
 Get an instance of the feature toggle manager:
 ```
-const myFeatureToggleManager = FeatureToggleManager.instance;
+const myFeatureToggleManager = FeatureToggleManager.Instance;
 ```
 
 Then, users can simply enter a command in the console to get output similar to the following:
@@ -34,9 +34,9 @@ feature_toggle_z ()
 ### GUI Toggle View
 To provide a graphical user interface to users, you will need an instance of `FeatureToggleDisplayPanel`:
 ```
-const myFeatureToggleManager = FeatureToggleManager.instance,
-      availableToggles = myFeatureToggleManager.toggles,
-      displayPanel = myFeatureToggleManager.createDisplayPanel(new FeatureToggleDisplayPanel(availableToggles));
+const myFeatureToggleManager = FeatureToggleManager.Instance,
+      availableToggles = myFeatureToggleManager.Toggles,
+      displayPanel = myFeatureToggleManager.CreateDisplayPanel(new FeatureToggleDisplayPanel(availableToggles));
 
 // displayPanel will be a div element containing the user interface.
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-feature-toggle-manager",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Tool for checking feature toggles",
   "main": "js-feature-toggle-manager.ts",
   "scripts": {

--- a/src/js-display-panel.ts
+++ b/src/js-display-panel.ts
@@ -78,8 +78,6 @@ export class FeatureToggleDisplayPanel extends DisplayPanel {
     sliderDisplayNode.classList.add('slider');
     sliderDisplayNode.setAttribute('data-reload-href', featureToggleUpdateLink);
     sliderDisplayNode.addEventListener('click', e => {
-      e.preventDefault();
-
       this.reloadPageWithUpdatedQueryString(featureToggleUpdateLink);
     });
 

--- a/src/js-feature-toggle-manager.test.ts
+++ b/src/js-feature-toggle-manager.test.ts
@@ -16,32 +16,32 @@ QUnit.test('can check for features enabled', assert => {
   toggleSetter.setToggle('feature_that_does_exist', true);
   toggleSetter.setToggle('feature_that_is_toggled_off', false);
   toggleSetter.writeToWindowToggles();
-  assert.ok(FeatureToggleManager.hasFeature('feature_that_does_exist'));
-  assert.notOk(FeatureToggleManager.hasFeature('feature_that_is_toggled_off'));
-  assert.notOk(FeatureToggleManager.hasFeature('feature_that_does_not_exist'));
+  assert.ok(FeatureToggleManager.HasFeature('feature_that_does_exist'));
+  assert.notOk(FeatureToggleManager.HasFeature('feature_that_is_toggled_off'));
+  assert.notOk(FeatureToggleManager.HasFeature('feature_that_does_not_exist'));
 });
 
 QUnit.test('Should work with undefined', assert => {
   window.sessionFeatureToggles = undefined;
-  assert.notOk(FeatureToggleManager.hasFeature(undefined), 'Undefined feature toggle should not exist');
+  assert.notOk(FeatureToggleManager.HasFeature(undefined), 'Undefined feature toggle should not exist');
 });
 
 QUnit.test('Should work with null', assert => {
   window.sessionFeatureToggles = null;
-  assert.notOk(FeatureToggleManager.hasFeature(null), 'NULL feature toggle should not exist');
+  assert.notOk(FeatureToggleManager.HasFeature(null), 'NULL feature toggle should not exist');
 });
 
 QUnit.test('Should not error out on an empty set of feature toggles.', assert => {
   const toggleSetter = new WindowToggleSetter();
   toggleSetter.writeToWindowToggles();
-  assert.notOk(FeatureToggleManager.hasFeature('a'), 'a feature toggle should not exist');
+  assert.notOk(FeatureToggleManager.HasFeature('a'), 'a feature toggle should not exist');
 });
 
 QUnit.test('Should find feature toggle', assert => {
   const toggleSetter = new WindowToggleSetter();
   toggleSetter.setToggle('catalog_notification', true);
   toggleSetter.writeToWindowToggles();
-  assert.ok(FeatureToggleManager.hasFeature('catalog_notification'), 'catalog_notification exists');
+  assert.ok(FeatureToggleManager.HasFeature('catalog_notification'), 'catalog_notification exists');
 });
 
 QUnit.test('Should return a string with current feature toggles and checkmark demarkation for those which are active.', assert => {
@@ -51,7 +51,7 @@ QUnit.test('Should return a string with current feature toggles and checkmark de
   windowSetter.setToggle('feature_toggle_z', false);
   windowSetter.writeToWindowToggles();
 
-  const manager = FeatureToggleManager.instance;
+  const manager = FeatureToggleManager.Instance;
   assert.ok(manager);
 
   const featureStrings = window.showFeatures().split('\n');
@@ -61,19 +61,19 @@ QUnit.test('Should return a string with current feature toggles and checkmark de
 });
 
 QUnit.test('Feature toggles are available as a public property of the instantiated FeatureToggleManager.', assert => {
-  const manager = FeatureToggleManager.instance;
+  const manager = FeatureToggleManager.Instance;
 
-  assert.equal(manager.toggles[0].Name, 'feature_toggle_x');
-  assert.equal(manager.toggles[0].IsActive, false);
-  assert.equal(manager.toggles[1].Name, 'feature_toggle_y');
-  assert.equal(manager.toggles[1].IsActive, true);
-  assert.equal(manager.toggles[2].Name, 'feature_toggle_z');
-  assert.equal(manager.toggles[2].IsActive, false);
+  assert.equal(manager.Toggles[0].Name, 'feature_toggle_x');
+  assert.equal(manager.Toggles[0].IsActive, false);
+  assert.equal(manager.Toggles[1].Name, 'feature_toggle_y');
+  assert.equal(manager.Toggles[1].IsActive, true);
+  assert.equal(manager.Toggles[2].Name, 'feature_toggle_z');
+  assert.equal(manager.Toggles[2].IsActive, false);
 });
 
 QUnit.test('Can create a UI interface for interacting with feature toggles.', assert => {
-  const manager = FeatureToggleManager.instance,
-        panel = manager.createDisplayPanel(new StubDisplayPanelFactory());
+  const manager = FeatureToggleManager.Instance,
+        panel = manager.CreateDisplayPanel(new StubDisplayPanelFactory());
   
   assert.ok(panel instanceof Element);
 });

--- a/src/js-feature-toggle-manager.test.ts
+++ b/src/js-feature-toggle-manager.test.ts
@@ -60,6 +60,17 @@ QUnit.test('Should return a string with current feature toggles and checkmark de
   assert.equal(featureStrings[3], 'feature_toggle_z ()');
 });
 
+QUnit.test('Feature toggles are available as a public property of the instantiated FeatureToggleManager.', assert => {
+  const manager = FeatureToggleManager.instance;
+
+  assert.equal(manager.toggles[0].Name, 'feature_toggle_x');
+  assert.equal(manager.toggles[0].IsActive, false);
+  assert.equal(manager.toggles[1].Name, 'feature_toggle_y');
+  assert.equal(manager.toggles[1].IsActive, true);
+  assert.equal(manager.toggles[2].Name, 'feature_toggle_z');
+  assert.equal(manager.toggles[2].IsActive, false);
+});
+
 QUnit.test('Can create a UI interface for interacting with feature toggles.', assert => {
   const manager = FeatureToggleManager.instance,
         panel = manager.createDisplayPanel(new StubDisplayPanelFactory());

--- a/src/js-feature-toggle-manager.ts
+++ b/src/js-feature-toggle-manager.ts
@@ -7,7 +7,7 @@ export interface ToggleStatus {
 
 export class FeatureToggleManager {  
   private static _instance: FeatureToggleManager;
-  private currentToggles: ToggleStatus[];
+  private _toggles: ToggleStatus[];
   
   /**
    * Check to see if a feature is currently active.
@@ -49,6 +49,13 @@ export class FeatureToggleManager {
   }
 
   /**
+   * Getter for available feature toggles.
+   */
+  public get toggles(): ToggleStatus[] {
+    return this._toggles;
+  }
+
+  /**
    * Creates a display panel that contains information and controls related to current feature toggles.
    */
   public createDisplayPanel(displayPanelFactory: IDisplayPanelFactory): Element {
@@ -58,12 +65,12 @@ export class FeatureToggleManager {
   }
 
   private constructor() {
-    this.currentToggles = FeatureToggleManager.getFeatureListFromWindow();
+    this._toggles = FeatureToggleManager.getFeatureListFromWindow();
     window.showFeatures = this.showFeatureToggles.bind(this);
   }
 
   private showFeatureToggles(): string {
-    return this.currentToggles.reduce((returnString, toggle) => {
+    return this._toggles.reduce((returnString, toggle) => {
       const activeIcon = toggle.IsActive ? '✓' : '';
       returnString += `${toggle.Name} (${activeIcon})\n`;
       return returnString;

--- a/src/js-feature-toggle-manager.ts
+++ b/src/js-feature-toggle-manager.ts
@@ -6,15 +6,15 @@ export interface ToggleStatus {
 }
 
 export class FeatureToggleManager {  
-  private static _instance: FeatureToggleManager;
-  private _toggles: ToggleStatus[];
+  private static instance: FeatureToggleManager;
+  private toggles: ToggleStatus[];
   
   /**
    * Check to see if a feature is currently active.
    * @param feature The feature to check for. Do not include the feature_toggle_ prefix.
    * @example For a feature_toggle_team_ordering feature, use hasFeature('product_page_team_ordering')
    */
-  public static hasFeature(targetFeature: string): boolean {
+  public static HasFeature(targetFeature: string): boolean {
     const features = this.getFeatureListFromWindow(),
           featureMatch = features.find(toggle => toggle.Name === targetFeature);
           
@@ -39,38 +39,38 @@ export class FeatureToggleManager {
   /**
    * Provides a getter method for Feature Toggle Manager singleton object.
    */
-  static get instance(): FeatureToggleManager {
-    if (undefined === this._instance) {
-      this._instance = new FeatureToggleManager();
-      return this._instance;
+  static get Instance(): FeatureToggleManager {
+    if (undefined === this.instance) {
+      this.instance = new FeatureToggleManager();
+      return this.instance;
     }
 
-    return this._instance;
+    return this.instance;
   }
 
   /**
    * Getter for available feature toggles.
    */
-  public get toggles(): ToggleStatus[] {
-    return this._toggles;
+  public get Toggles(): ToggleStatus[] {
+    return this.toggles;
   }
 
   /**
    * Creates a display panel that contains information and controls related to current feature toggles.
    */
-  public createDisplayPanel(displayPanelFactory: IDisplayPanelFactory): Element {
+  public CreateDisplayPanel(displayPanelFactory: IDisplayPanelFactory): Element {
     const panel = displayPanelFactory.createDisplayPanel();
     
     return panel.draw();
   }
 
   private constructor() {
-    this._toggles = FeatureToggleManager.getFeatureListFromWindow();
+    this.toggles = FeatureToggleManager.getFeatureListFromWindow();
     window.showFeatures = this.showFeatureToggles.bind(this);
   }
 
   private showFeatureToggles(): string {
-    return this._toggles.reduce((returnString, toggle) => {
+    return this.toggles.reduce((returnString, toggle) => {
       const activeIcon = toggle.IsActive ? '✓' : '';
       returnString += `${toggle.Name} (${activeIcon})\n`;
       return returnString;


### PR DESCRIPTION
It turns out that we need to have a way to access feature toggles from outside the manager in order to create the display panel.

I also updated the ReadMe accordingly.